### PR TITLE
Use latest elixir/erlang

### DIFF
--- a/elixir-centos/Dockerfile
+++ b/elixir-centos/Dockerfile
@@ -1,8 +1,8 @@
 FROM centos:7
 MAINTAINER Daniel Temme <daniel@qixxit.de>
 
-ENV ERLANG_VERSION=20.3
-ENV ELIXIR_VERSION=1.6.6
+ENV ERLANG_VERSION=21.1.1
+ENV ELIXIR_VERSION=1.7.4
 ENV RUBY_VERSION=2.4.3
 ENV ERL_AFLAGS="-kernel shell_history enabled"
 


### PR DESCRIPTION
I suppose we should test against these versions on circle as its what we'll be running locally with the merge of https://github.com/qixxit/qixxit_server/pull/2364

I'm unsure though whether I should make this change before or after updating the servers themselves. @dmt do you think that matters? I suppose that as long as the app works with either version (it does currently), that should not be a concern. What do you think?